### PR TITLE
feat: Enhance SummaryStats with cutoff score fetching and display

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -343,7 +343,7 @@ export const FilterBar: React.FC<FilterBarProps> = ({
 
         {showLimit && (
           <div className="filter-label">
-            <span>Top N:</span>
+            <span>Top N runs:</span>
             <select
               className="filter-select"
               value={filter.limit}

--- a/src/components/styles/SummaryStats.css
+++ b/src/components/styles/SummaryStats.css
@@ -62,6 +62,11 @@
   background-clip: text;
 }
 
+/* Smaller numbers only for the cutoff summary card */
+.stats-card.cutoff-card .value {
+  font-size: 1.2rem;
+}
+
 /* Spec role sections */
 .spec-role-section {
   background: linear-gradient(135deg, rgba(30, 41, 59, 0.95) 0%, rgba(51, 65, 85, 0.95) 100%);


### PR DESCRIPTION
- Integrated fetching of the latest 0.1% cutoff scores for US and EU regions using the Raider.IO API.
- Added loading state management for cutoff score retrieval.
- Updated SummaryStats component to display current cutoff scores with a button for detailed view.
- Improved styling for the cutoff summary card in SummaryStats.css.